### PR TITLE
Add Windows thumbar & enhance player controls

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,6 +48,46 @@ const resolveAppIcon = () => {
 
 const appIcon = resolveAppIcon();
 
+// Taskbar thumbnail toolbar icons (20×20 white-on-transparent PNG, base64 encoded)
+const THUMBAR_ICON_PLAY   = 'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAASElEQVR4nO3OwQ0AIAgEQfpvGvVnDOjBET+6BUxW5DfSXjlYiupSOUijFkjBOzCFnsAwjIIwfP0QhhAwjHlgCvJACptBGnqjBvgKUrwixhObAAAAAElFTkSuQmCC';
+const THUMBAR_ICON_PAUSE  = 'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAHklEQVR4nGNgGAX/0QCp8qMGjho4auCogcQZOPwBAE+QvlDSK5bqAAAAAElFTkSuQmCC';
+const THUMBAR_ICON_PREV   = 'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAASklEQVR4nOXQQQoAIAhEUe9/aduGiM04RVB/rQ/R7O98itnZAkKzKOghCYxYG8ygNlhhNLjCKBDB7l545IcI2gIrWAIzVAbZ2ccbRwXyHOtSMyYAAAAASUVORK5CYII=';
+const THUMBAR_ICON_NEXT   = 'iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAASklEQVR4nGNgGAX/gYBYdTBAlEKqG0hIIVkG4lNMtoG4NFFsILpGqhiIrJlqBhJy+cC6EJc6sgzEp44kA4lRR7SB1FBH/bw8/AEA5YzCTPEG4HoAAAAASUVORK5CYII=';
+
+function updateThumbarButtons(isPlaying, hasActiveSong) {
+  if (!mainWindow || process.platform !== 'win32') return;
+  const flags = hasActiveSong ? [] : ['disabled'];
+  mainWindow.setThumbarButtons([
+    {
+      tooltip: '上一曲',
+      icon: nativeImage.createFromBuffer(Buffer.from(THUMBAR_ICON_PREV, 'base64')),
+      click: () => mainWindow?.webContents.send('player-control', 'prev'),
+      flags,
+    },
+    {
+      tooltip: isPlaying ? '暂停' : '播放',
+      icon: nativeImage.createFromBuffer(Buffer.from(isPlaying ? THUMBAR_ICON_PAUSE : THUMBAR_ICON_PLAY, 'base64')),
+      click: () => mainWindow?.webContents.send('player-control', 'toggle-play'),
+      flags,
+    },
+    {
+      tooltip: '下一曲',
+      icon: nativeImage.createFromBuffer(Buffer.from(THUMBAR_ICON_NEXT, 'base64')),
+      click: () => mainWindow?.webContents.send('player-control', 'next'),
+      flags,
+    },
+  ]);
+}
+
+function updateTaskbarProgress(currentTime, duration) {
+  if (!mainWindow || process.platform !== 'win32') return;
+  if (!duration || duration <= 0) {
+    mainWindow.setProgressBar(-1);
+  } else {
+    mainWindow.setProgressBar(currentTime / duration);
+  }
+}
+
 if (customUserDataPath) {
   fs.mkdirSync(customUserDataPath, { recursive: true });
   app.setPath('userData', customUserDataPath);
@@ -303,6 +343,7 @@ function createWindow() {
 
   mainWindow.once('ready-to-show', () => {
     updateWindowShape();
+    updateThumbarButtons(false, false);
   });
 
   mainWindow.on('closed', () => {
@@ -465,4 +506,9 @@ ipcMain.handle('window:restart-with-shell-mode', async (event, transparentWindow
   app.relaunch();
   app.exit(0);
   return true;
+});
+
+ipcMain.on('media:update-playback-state', (_event, { isPlaying, hasActiveSong, currentTime, duration }) => {
+  updateThumbarButtons(isPlaying, hasActiveSong);
+  updateTaskbarProgress(currentTime, duration);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radiflow-player",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "radiflow-player",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@google/genai": "^1.29.0",
         "@tailwindcss/vite": "^4.1.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "radiflow-player",
   "productName": "RadiFlow Player",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "RadiFlow Player is a desktop music player with dynamic backgrounds, synced lyrics, playlists, and local library support.",
   "type": "module",
   "main": "main.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import {
 const ipc = (window as any).require ? (window as any).require('electron').ipcRenderer : null;
 
 const APP_NAME = 'RadiFlow Player';
-const APP_VERSION = '0.1.0';
+const APP_VERSION = '0.1.2';
 const PLAYLIST_STORAGE_KEY = 'apple-music-style-player.playlists';
 const PREFERENCES_STORAGE_KEY = 'apple-music-style-player.preferences';
 const PREFERENCES_STORAGE_VERSION = 3;
@@ -878,6 +878,11 @@ export default function App() {
       audioRef.current.volume = volume;
     }
   }, [volume]);
+
+  useEffect(() => {
+    if (!ipc) return;
+    ipc.send('media:update-playback-state', { isPlaying, hasActiveSong, currentTime, duration });
+  }, [isPlaying, hasActiveSong, currentTime, duration]);
 
   const playSongs = async (songsToPlay: Song[], index: number, sourcePlaylistId: string | null = null) => {
     if (index < 0 || index >= songsToPlay.length) return;

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { motion } from 'motion/react';
+import React, { useRef, useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
 import { Play, Pause, SkipBack, SkipForward, Music, Volume2, VolumeX } from 'lucide-react';
 
 interface MiniPlayerProps {
@@ -31,6 +31,45 @@ export const MiniPlayer: React.FC<MiniPlayerProps> = ({
   onVolumeChange,
   emptyActionLabel,
 }) => {
+  const [showVolumePopover, setShowVolumePopover] = useState(false);
+  const volumeHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isDraggingVolume = useRef(false);
+
+  useEffect(() => () => {
+    if (volumeHideTimerRef.current) clearTimeout(volumeHideTimerRef.current);
+  }, []);
+
+  const openVolume = () => {
+    if (volumeHideTimerRef.current) clearTimeout(volumeHideTimerRef.current);
+    setShowVolumePopover(true);
+  };
+
+  const scheduleCloseVolume = () => {
+    volumeHideTimerRef.current = setTimeout(() => {
+      if (!isDraggingVolume.current) setShowVolumePopover(false);
+    }, 300);
+  };
+
+  const handleVolumeTrackPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    isDraggingVolume.current = true;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const rect = e.currentTarget.getBoundingClientRect();
+    onVolumeChange(Math.max(0, Math.min(1, 1 - (e.clientY - rect.top) / rect.height)));
+  };
+
+  const handleVolumeTrackPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingVolume.current) return;
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    onVolumeChange(Math.max(0, Math.min(1, 1 - (e.clientY - rect.top) / rect.height)));
+  };
+
+  const handleVolumeTrackPointerUp = () => {
+    isDraggingVolume.current = false;
+    scheduleCloseVolume();
+  };
+
   return (
     <motion.div
       initial={{ y: 100, opacity: 0 }}
@@ -82,23 +121,45 @@ export const MiniPlayer: React.FC<MiniPlayerProps> = ({
                 </button>
               </div>
 
-              <div className="hidden sm:flex items-center gap-2 group/vol">
-                <button 
-                  onClick={() => onVolumeChange(volume === 0 ? 0.8 : 0)}
-                  className="text-white/40 hover:text-white transition-colors"
+              <div className="hidden sm:flex items-center gap-2">
+                <div
+                  className="relative"
+                  onMouseEnter={openVolume}
+                  onMouseLeave={scheduleCloseVolume}
+                  onClick={e => e.stopPropagation()}
                 >
-                  {volume === 0 ? <VolumeX size={16} /> : <Volume2 size={16} />}
-                </button>
-                <div className="w-0 group-hover/vol:w-20 overflow-hidden transition-all duration-300 flex items-center">
-                  <input 
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.01"
-                    value={volume}
-                    onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
-                    className="w-full h-1 bg-white/20 rounded-full appearance-none cursor-pointer accent-white"
-                  />
+                  <AnimatePresence>
+                    {showVolumePopover && (
+                      <motion.div
+                        initial={{ opacity: 0, scale: 0.92, y: 4 }}
+                        animate={{ opacity: 1, scale: 1, y: 0 }}
+                        exit={{ opacity: 0, scale: 0.92, y: 4 }}
+                        transition={{ duration: 0.15 }}
+                        className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 flex flex-col items-center gap-1.5 px-3 pt-3 pb-2 rounded-xl bg-black/70 backdrop-blur-xl border border-white/10 shadow-xl z-10"
+                        onMouseEnter={openVolume}
+                        onMouseLeave={scheduleCloseVolume}
+                      >
+                        <span className="text-[9px] font-mono text-white/50 tabular-nums">{Math.round(volume * 100)}</span>
+                        <div
+                          className="relative w-1.5 h-20 bg-white/20 rounded-full cursor-pointer touch-none select-none"
+                          onPointerDown={handleVolumeTrackPointerDown}
+                          onPointerMove={handleVolumeTrackPointerMove}
+                          onPointerUp={handleVolumeTrackPointerUp}
+                        >
+                          <div
+                            className="absolute bottom-0 left-0 w-full rounded-full bg-white"
+                            style={{ height: `${volume * 100}%` }}
+                          />
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                  <button
+                    onClick={() => onVolumeChange(volume === 0 ? 0.8 : 0)}
+                    className="p-2 text-white/40 hover:text-white transition-colors"
+                  >
+                    {volume === 0 ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                  </button>
                 </div>
               </div>
             </>

--- a/src/components/PlayerControls.tsx
+++ b/src/components/PlayerControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { Play, Pause, SkipBack, SkipForward, Volume2, Music, ListMusic, Repeat, Repeat1, Shuffle, Mic2, ChevronDown } from 'lucide-react';
 import { motion } from 'motion/react';
 import { cn } from '../lib/utils';
@@ -72,6 +72,47 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
 
   const progressWidth = duration > 0 ? `${(currentTime / duration) * 100}%` : '0%';
 
+  const isDraggingProgress = useRef(false);
+  const [progressDragging, setProgressDragging] = useState(false);
+  const isDraggingVolume = useRef(false);
+
+  const handleProgressPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (controlsDisabled) return;
+    isDraggingProgress.current = true;
+    setProgressDragging(true);
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const rect = e.currentTarget.getBoundingClientRect();
+    onSeek(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) * duration);
+  };
+
+  const handleProgressPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingProgress.current) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    onSeek(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)) * duration);
+  };
+
+  const handleProgressPointerUp = () => {
+    isDraggingProgress.current = false;
+    setProgressDragging(false);
+  };
+
+  const handleVolumePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    isDraggingVolume.current = true;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const rect = e.currentTarget.getBoundingClientRect();
+    onVolumeChange(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)));
+  };
+
+  const handleVolumePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingVolume.current) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    onVolumeChange(Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)));
+  };
+
+  const handleVolumePointerUp = () => {
+    isDraggingVolume.current = false;
+  };
+
   return (
     <div className="flex flex-col gap-6 w-full max-w-md">
       <div className="flex items-start justify-between overflow-hidden pl-4">
@@ -92,16 +133,15 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
       </div>
 
       <div className="flex flex-col gap-2">
-        <div className="relative h-1.5 w-full bg-white/10 rounded-full overflow-hidden cursor-pointer group"
-             onClick={(e) => {
-               if (controlsDisabled) return;
-               const rect = e.currentTarget.getBoundingClientRect();
-               const x = e.clientX - rect.left;
-               onSeek((x / rect.width) * duration);
-             }}>
-          <div 
-            className="absolute top-0 left-0 h-full bg-white transition-all duration-100"
-            style={{ width: progressWidth }}
+        <div
+          className="relative h-1.5 w-full bg-white/10 rounded-full overflow-hidden cursor-pointer group touch-none"
+          onPointerDown={handleProgressPointerDown}
+          onPointerMove={handleProgressPointerMove}
+          onPointerUp={handleProgressPointerUp}
+        >
+          <div
+            className="absolute top-0 left-0 h-full bg-white"
+            style={{ width: progressWidth, transition: progressDragging ? 'none' : 'width 100ms' }}
           />
         </div>
         <div className="flex justify-between text-[10px] font-mono text-white/40 uppercase tracking-widest">
@@ -183,14 +223,14 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
           <Volume2 size={12} />
           <span>Volume</span>
         </div>
-        <div className="relative h-1 w-full bg-white/10 rounded-full overflow-hidden cursor-pointer group"
-             onClick={(e) => {
-               const rect = e.currentTarget.getBoundingClientRect();
-               const x = e.clientX - rect.left;
-               onVolumeChange(Math.max(0, Math.min(1, x / rect.width)));
-             }}>
-          <div 
-            className="absolute top-0 left-0 h-full bg-white/60 transition-all duration-100"
+        <div
+          className="relative h-1 w-full bg-white/10 rounded-full overflow-hidden cursor-pointer group touch-none"
+          onPointerDown={handleVolumePointerDown}
+          onPointerMove={handleVolumePointerMove}
+          onPointerUp={handleVolumePointerUp}
+        >
+          <div
+            className="absolute top-0 left-0 h-full bg-white/60"
             style={{ width: `${volume * 100}%` }}
           />
         </div>


### PR DESCRIPTION
Add Windows taskbar/thumbar support and taskbar progress reporting (main.js): base64 icons, updateThumbarButtons, updateTaskbarProgress, and ipc handler for media state. Wire renderer to send playback state from App.tsx via ipc when isPlaying/hasActiveSong/currentTime/duration change. Improve in-app controls: MiniPlayer gets an animated volume popover with pointer drag/capture and hover behavior; PlayerControls now supports pointer-based dragging for progress and volume with smoother transitions and touch-friendly behavior. Bump app version to 0.1.2 in package.json (and lockfile).