### PR TITLE
Add EQ UI and lyrics caching/database

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,6 +3,7 @@ import { createHash } from "crypto";
 import fs from "fs";
 import type { Server } from "http";
 import { parseFile } from "music-metadata";
+import { DatabaseSync } from "node:sqlite";
 import path from "path";
 import { fileURLToPath } from "url";
 import { gunzipSync, gzipSync } from "zlib";
@@ -17,6 +18,11 @@ const LIBRARY_CACHE_FILE_NAME = 'library-cache.json';
 const LIBRARY_CACHE_COVER_BUNDLE_FILE_NAME = 'cover-cache.json.gz';
 const LEGACY_LIBRARY_CACHE_IMAGE_DIRECTORY_NAME = 'image';
 const LIBRARY_CACHE_VERSION = 1;
+const LYRIC_CACHE_DIRECTORY_NAME = 'lyric';
+const LYRIC_CACHE_INDEX_FILE_NAME = 'index.json';
+const LYRIC_CACHE_VERSION = 1;
+const LYRIC_CACHE_DB_FILE_NAME = 'lyrics.db';
+const MANUAL_LYRIC_EXTENSIONS = new Set(['.lrc', '.yrc', '.txt']);
 
 interface LibrarySongPayload {
   filename: string;
@@ -47,6 +53,49 @@ interface PersistedCoverBundle {
   assets: Record<string, PersistedCoverAsset>;
 }
 
+interface PersistedLyricData {
+  lrc?: string;
+  lyric?: string;
+  tlyric?: string;
+  trans?: string;
+  yrc?: string;
+}
+
+interface PersistedLyricFile {
+  version: number;
+  title: string;
+  artist: string;
+  songId: string | null;
+  savedAt: string;
+  data: PersistedLyricData;
+}
+
+interface PersistedLyricIndexEntry {
+  cacheFile: string;
+  title: string;
+  artist: string;
+  savedAt: string;
+}
+
+interface PersistedLyricIndex {
+  version: number;
+  folder: string;
+  generatedAt: string;
+  entries: Record<string, PersistedLyricIndexEntry>;
+}
+
+interface PersistedLyricDatabaseRow {
+  title: string;
+  artist: string;
+  song_id: string | null;
+  lrc: string | null;
+  lyric: string | null;
+  tlyric: string | null;
+  trans: string | null;
+  yrc: string | null;
+  saved_at: string;
+}
+
 interface StartServerOptions {
   port?: number;
   host?: string;
@@ -62,14 +111,427 @@ interface StartedServer {
   server: Server;
 }
 
+let lyricDatabaseState: { musicDir: string; database: DatabaseSync } | null = null;
+
 const getCacheKey = (filePath: string, stats: fs.Stats) => `${filePath}|${stats.mtimeMs}|${stats.size}`;
 const getLibraryCacheDirectory = (musicDir: string) => path.join(musicDir, LIBRARY_CACHE_DIRECTORY_NAME);
 const getLibraryCacheFilePath = (musicDir: string) => path.join(getLibraryCacheDirectory(musicDir), LIBRARY_CACHE_FILE_NAME);
 const getLibraryCoverBundleFilePath = (musicDir: string) => path.join(getLibraryCacheDirectory(musicDir), LIBRARY_CACHE_COVER_BUNDLE_FILE_NAME);
+const getLyricCacheDirectory = (musicDir: string) => path.join(musicDir, LYRIC_CACHE_DIRECTORY_NAME);
+const getLyricCacheIndexFilePath = (musicDir: string) => path.join(getLyricCacheDirectory(musicDir), LYRIC_CACHE_INDEX_FILE_NAME);
+const getLyricCacheDatabaseFilePath = (musicDir: string) => path.join(getLyricCacheDirectory(musicDir), LYRIC_CACHE_DB_FILE_NAME);
 const isRefreshRequested = (value: unknown) => value === '1' || value === 'true';
 
 const ensureDirectory = (directoryPath: string) => {
   fs.mkdirSync(directoryPath, { recursive: true });
+};
+
+const normalizeLyricLookupPart = (value: string) => value.trim().toLowerCase().replace(/\s+/g, ' ');
+
+const resolveLyricFileNameFromUrl = (fileUrl?: string) => {
+  if (!fileUrl || !fileUrl.startsWith('/music/')) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(fileUrl.slice('/music/'.length));
+  } catch {
+    return null;
+  }
+};
+
+const getLyricAssociationKeys = ({
+  title,
+  artist,
+  fileUrl,
+}: {
+  title: string;
+  artist: string;
+  fileUrl?: string;
+}) => {
+  const keys = new Set<string>();
+  const normalizedTitle = normalizeLyricLookupPart(title);
+  const normalizedArtist = normalizeLyricLookupPart(artist);
+  const fileName = resolveLyricFileNameFromUrl(fileUrl);
+
+  if (normalizedTitle && normalizedArtist) {
+    keys.add(`track:${normalizedTitle}::${normalizedArtist}`);
+  }
+
+  if (fileName) {
+    keys.add(`file:${fileName.toLowerCase()}`);
+  }
+
+  return Array.from(keys);
+};
+
+const sanitizeLyricPayload = (value: unknown): PersistedLyricData => {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const payload: PersistedLyricData = {};
+
+  if (typeof candidate.lrc === 'string') {
+    payload.lrc = candidate.lrc;
+  }
+
+  if (typeof candidate.lyric === 'string') {
+    payload.lyric = candidate.lyric;
+  }
+
+  if (typeof candidate.tlyric === 'string') {
+    payload.tlyric = candidate.tlyric;
+  }
+
+  if (typeof candidate.trans === 'string') {
+    payload.trans = candidate.trans;
+  }
+
+  if (typeof candidate.yrc === 'string') {
+    payload.yrc = candidate.yrc;
+  }
+
+  return payload;
+};
+
+const hasUsableLyrics = (payload: PersistedLyricData) => Boolean(
+  payload.yrc?.trim() || payload.lrc?.trim() || payload.lyric?.trim()
+);
+
+const getManualLyricPayload = (musicDir: string, fileUrl?: string): PersistedLyricData | null => {
+  const musicFileName = resolveLyricFileNameFromUrl(fileUrl);
+  if (!musicFileName) {
+    return null;
+  }
+
+  const lyricDirectory = getLyricCacheDirectory(musicDir);
+  if (!fs.existsSync(lyricDirectory)) {
+    return null;
+  }
+
+  const expectedBaseName = path.parse(musicFileName).name.toLowerCase();
+  const matchedLyricFile = fs.readdirSync(lyricDirectory).find((entry) => {
+    const parsedEntry = path.parse(entry);
+    return parsedEntry.name.toLowerCase() === expectedBaseName
+      && MANUAL_LYRIC_EXTENSIONS.has(parsedEntry.ext.toLowerCase());
+  });
+
+  if (!matchedLyricFile) {
+    return null;
+  }
+
+  try {
+    const lyricFilePath = path.join(lyricDirectory, matchedLyricFile);
+    const lyricText = fs.readFileSync(lyricFilePath, 'utf8').trim();
+    if (!lyricText) {
+      return null;
+    }
+
+    return path.extname(matchedLyricFile).toLowerCase() === '.yrc'
+      ? { yrc: lyricText }
+      : { lrc: lyricText };
+  } catch {
+    return null;
+  }
+};
+
+const getLyricDatabase = (musicDir: string) => {
+  if (lyricDatabaseState?.musicDir === musicDir) {
+    return lyricDatabaseState.database;
+  }
+
+  if (lyricDatabaseState) {
+    lyricDatabaseState.database.close();
+    lyricDatabaseState = null;
+  }
+
+  ensureDirectory(getLyricCacheDirectory(musicDir));
+
+  const database = new DatabaseSync(getLyricCacheDatabaseFilePath(musicDir));
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS lyric_cache (
+      association_key TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      artist TEXT NOT NULL,
+      file_name TEXT,
+      song_id TEXT,
+      lrc TEXT,
+      lyric TEXT,
+      tlyric TEXT,
+      trans TEXT,
+      yrc TEXT,
+      saved_at TEXT NOT NULL
+    );
+  `);
+
+  lyricDatabaseState = { musicDir, database };
+  return database;
+};
+
+const getLyricCacheFileName = (title: string, artist: string, songId?: string | null) => {
+  const digest = createHash('sha1')
+    .update(normalizeLyricLookupPart(title))
+    .update('::')
+    .update(normalizeLyricLookupPart(artist))
+    .update('::')
+    .update(songId ?? '')
+    .digest('hex');
+
+  return `${digest}.json`;
+};
+
+const readPersistedLyricIndex = (musicDir: string): PersistedLyricIndex | null => {
+  try {
+    const indexFilePath = getLyricCacheIndexFilePath(musicDir);
+    if (!fs.existsSync(indexFilePath)) {
+      return null;
+    }
+
+    const rawIndex = fs.readFileSync(indexFilePath, 'utf8');
+    const parsedIndex = JSON.parse(rawIndex) as Partial<PersistedLyricIndex>;
+
+    if (parsedIndex.version !== LYRIC_CACHE_VERSION || parsedIndex.folder !== musicDir || !parsedIndex.entries || typeof parsedIndex.entries !== 'object') {
+      return null;
+    }
+
+    return {
+      version: LYRIC_CACHE_VERSION,
+      folder: musicDir,
+      generatedAt: typeof parsedIndex.generatedAt === 'string' ? parsedIndex.generatedAt : new Date(0).toISOString(),
+      entries: parsedIndex.entries as Record<string, PersistedLyricIndexEntry>,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const persistLyricIndex = (musicDir: string, entries: Record<string, PersistedLyricIndexEntry>) => {
+  ensureDirectory(getLyricCacheDirectory(musicDir));
+
+  const payload: PersistedLyricIndex = {
+    version: LYRIC_CACHE_VERSION,
+    folder: musicDir,
+    generatedAt: new Date().toISOString(),
+    entries,
+  };
+
+  const indexFilePath = getLyricCacheIndexFilePath(musicDir);
+  const tempIndexFilePath = `${indexFilePath}.tmp`;
+  fs.writeFileSync(tempIndexFilePath, JSON.stringify(payload), 'utf8');
+  fs.renameSync(tempIndexFilePath, indexFilePath);
+
+  return payload;
+};
+
+const readPersistedLyricFile = (musicDir: string, cacheFile: string): PersistedLyricFile | null => {
+  try {
+    const lyricFilePath = path.join(getLyricCacheDirectory(musicDir), cacheFile);
+    if (!fs.existsSync(lyricFilePath)) {
+      return null;
+    }
+
+    const rawPayload = fs.readFileSync(lyricFilePath, 'utf8');
+    const parsedPayload = JSON.parse(rawPayload) as Partial<PersistedLyricFile>;
+    const lyricData = sanitizeLyricPayload(parsedPayload.data);
+
+    if (parsedPayload.version !== LYRIC_CACHE_VERSION || !hasUsableLyrics(lyricData)) {
+      return null;
+    }
+
+    return {
+      version: LYRIC_CACHE_VERSION,
+      title: typeof parsedPayload.title === 'string' ? parsedPayload.title : '',
+      artist: typeof parsedPayload.artist === 'string' ? parsedPayload.artist : '',
+      songId: typeof parsedPayload.songId === 'string' ? parsedPayload.songId : null,
+      savedAt: typeof parsedPayload.savedAt === 'string' ? parsedPayload.savedAt : new Date(0).toISOString(),
+      data: lyricData,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const getPersistedLyricPayload = (
+  musicDir: string,
+  association: { title: string; artist: string; fileUrl?: string },
+) => {
+  const lyricIndex = readPersistedLyricIndex(musicDir);
+  if (!lyricIndex) {
+    return null;
+  }
+
+  for (const key of getLyricAssociationKeys(association)) {
+    const entry = lyricIndex.entries[key];
+    if (!entry) {
+      continue;
+    }
+
+    const payload = readPersistedLyricFile(musicDir, entry.cacheFile);
+    if (payload) {
+      return payload;
+    }
+  }
+
+  return null;
+};
+
+const persistLyricPayload = (
+  musicDir: string,
+  association: { title: string; artist: string; fileUrl?: string },
+  payloadData: PersistedLyricData,
+  songId?: string | null,
+) => {
+  ensureDirectory(getLyricCacheDirectory(musicDir));
+
+  const cacheFile = getLyricCacheFileName(association.title, association.artist, songId);
+  const payload: PersistedLyricFile = {
+    version: LYRIC_CACHE_VERSION,
+    title: association.title,
+    artist: association.artist,
+    songId: songId ?? null,
+    savedAt: new Date().toISOString(),
+    data: payloadData,
+  };
+
+  const lyricFilePath = path.join(getLyricCacheDirectory(musicDir), cacheFile);
+  const tempLyricFilePath = `${lyricFilePath}.tmp`;
+  fs.writeFileSync(tempLyricFilePath, JSON.stringify(payload), 'utf8');
+  fs.renameSync(tempLyricFilePath, lyricFilePath);
+
+  const existingIndex = readPersistedLyricIndex(musicDir);
+  const nextEntries: Record<string, PersistedLyricIndexEntry> = {
+    ...(existingIndex?.entries ?? {}),
+  };
+
+  for (const key of getLyricAssociationKeys(association)) {
+    nextEntries[key] = {
+      cacheFile,
+      title: association.title,
+      artist: association.artist,
+      savedAt: payload.savedAt,
+    };
+  }
+
+  persistLyricIndex(musicDir, nextEntries);
+  return payload;
+};
+
+const getPersistedLyricPayloadFromDatabase = (
+  musicDir: string,
+  association: { title: string; artist: string; fileUrl?: string },
+) => {
+  const database = getLyricDatabase(musicDir);
+  const statement = database.prepare(`
+    SELECT title, artist, song_id, lrc, lyric, tlyric, trans, yrc, saved_at
+    FROM lyric_cache
+    WHERE association_key = ?
+    LIMIT 1
+  `);
+
+  for (const key of getLyricAssociationKeys(association)) {
+    const row = statement.get(key) as PersistedLyricDatabaseRow | undefined;
+    if (!row) {
+      continue;
+    }
+
+    const lyricData = sanitizeLyricPayload(row);
+    if (!hasUsableLyrics(lyricData)) {
+      continue;
+    }
+
+    return {
+      version: LYRIC_CACHE_VERSION,
+      title: row.title,
+      artist: row.artist,
+      songId: row.song_id,
+      savedAt: row.saved_at,
+      data: lyricData,
+    } satisfies PersistedLyricFile;
+  }
+
+  return null;
+};
+
+const persistLyricPayloadToDatabase = (
+  musicDir: string,
+  association: { title: string; artist: string; fileUrl?: string },
+  payloadData: PersistedLyricData,
+  songId?: string | null,
+) => {
+  const database = getLyricDatabase(musicDir);
+  const fileName = resolveLyricFileNameFromUrl(association.fileUrl);
+  const savedAt = new Date().toISOString();
+  const statement = database.prepare(`
+    INSERT INTO lyric_cache (
+      association_key,
+      title,
+      artist,
+      file_name,
+      song_id,
+      lrc,
+      lyric,
+      tlyric,
+      trans,
+      yrc,
+      saved_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(association_key) DO UPDATE SET
+      title = excluded.title,
+      artist = excluded.artist,
+      file_name = excluded.file_name,
+      song_id = excluded.song_id,
+      lrc = excluded.lrc,
+      lyric = excluded.lyric,
+      tlyric = excluded.tlyric,
+      trans = excluded.trans,
+      yrc = excluded.yrc,
+      saved_at = excluded.saved_at
+  `);
+
+  for (const key of getLyricAssociationKeys(association)) {
+    statement.run(
+      key,
+      association.title,
+      association.artist,
+      fileName ?? null,
+      songId ?? null,
+      payloadData.lrc ?? null,
+      payloadData.lyric ?? null,
+      payloadData.tlyric ?? null,
+      payloadData.trans ?? null,
+      payloadData.yrc ?? null,
+      savedAt,
+    );
+  }
+
+  return {
+    version: LYRIC_CACHE_VERSION,
+    title: association.title,
+    artist: association.artist,
+    songId: songId ?? null,
+    savedAt,
+    data: payloadData,
+  } satisfies PersistedLyricFile;
+};
+
+const getStoredLyricPayload = (
+  musicDir: string,
+  association: { title: string; artist: string; fileUrl?: string },
+) => {
+  const databasePayload = getPersistedLyricPayloadFromDatabase(musicDir, association);
+  if (databasePayload) {
+    return databasePayload;
+  }
+
+  const legacyPayload = getPersistedLyricPayload(musicDir, association);
+  if (!legacyPayload) {
+    return null;
+  }
+
+  persistLyricPayloadToDatabase(musicDir, association, legacyPayload.data, legacyPayload.songId);
+  return legacyPayload;
 };
 
 const getCoverFileExtension = (mimeType?: string) => {
@@ -403,6 +865,102 @@ export async function startServer(options: StartServerOptions = {}): Promise<Sta
     res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
     res.type(coverAsset.mimeType);
     res.send(Buffer.from(coverAsset.data, 'base64'));
+  });
+
+  app.get('/api/lyrics', async (req, res) => {
+    const title = typeof req.query.title === 'string' ? req.query.title.trim() : '';
+    const artist = typeof req.query.artist === 'string' ? req.query.artist.trim() : '';
+    const fileUrl = typeof req.query.file === 'string' ? req.query.file : undefined;
+    const manualLyricPayload = getManualLyricPayload(musicDir, fileUrl);
+
+    if (!title || !artist) {
+      res.status(400).json({ code: 400, error: 'Missing title or artist' });
+      return;
+    }
+
+    const cachedPayload = getStoredLyricPayload(musicDir, { title, artist, fileUrl });
+    if (cachedPayload) {
+      res.json({
+        code: 200,
+        data: cachedPayload.data,
+        source: 'local',
+      });
+      return;
+    }
+
+    try {
+      const searchResponse = await fetch(`https://api.vkeys.cn/v2/music/tencent/search/song?word=${encodeURIComponent(`${title} ${artist}`)}`);
+      const searchData = await searchResponse.json() as {
+        code?: number;
+        data?: unknown[] | { list?: unknown[] };
+      };
+      const results = Array.isArray(searchData.data)
+        ? searchData.data
+        : Array.isArray(searchData.data?.list)
+          ? searchData.data.list
+          : [];
+
+      if (searchData.code !== 200 || results.length === 0) {
+        if (manualLyricPayload) {
+          res.json({
+            code: 200,
+            data: manualLyricPayload,
+            source: 'manual',
+          });
+          return;
+        }
+
+        res.status(404).json({ code: 404, error: 'Song not found in search results' });
+        return;
+      }
+
+      const firstSong = results[0] as Record<string, unknown>;
+      const songId = firstSong.id ?? firstSong.songid ?? firstSong.songmid;
+      if (typeof songId !== 'string' && typeof songId !== 'number') {
+        res.status(404).json({ code: 404, error: 'Could not find song ID' });
+        return;
+      }
+
+      const lyricResponse = await fetch(`https://api.vkeys.cn/v2/music/tencent/lyric?id=${songId}`);
+      const lyricResponseData = await lyricResponse.json() as {
+        code?: number;
+        data?: unknown;
+      };
+      const lyricPayload = sanitizeLyricPayload(lyricResponseData.data);
+
+      if (lyricResponseData.code !== 200 || !hasUsableLyrics(lyricPayload)) {
+        if (manualLyricPayload) {
+          res.json({
+            code: 200,
+            data: manualLyricPayload,
+            source: 'manual',
+          });
+          return;
+        }
+
+        res.status(404).json({ code: 404, error: 'Lyrics not found in API response' });
+        return;
+      }
+
+      persistLyricPayloadToDatabase(musicDir, { title, artist, fileUrl }, lyricPayload, String(songId));
+
+      res.json({
+        code: 200,
+        data: lyricPayload,
+        source: 'remote',
+      });
+    } catch {
+      if (manualLyricPayload) {
+        res.json({
+          code: 200,
+          data: manualLyricPayload,
+          source: 'manual',
+        });
+        return;
+      }
+
+      res.status(500).json({ code: 500, error: 'Failed to fetch lyrics' });
+    }
   });
 
   // Proxy for vkeys API to avoid CORS

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Disc, ListMusic, Maximize2, Minimize2, Music, Pencil, Plus, Search, Settings2, Trash2, User } from 'lucide-react';
+import { Disc, ListMusic, Maximize2, Minimize2, Music, Pencil, Plus, Search, Settings2, SlidersHorizontal, Trash2, User } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { Background } from './components/Background';
+import { EQView } from './components/EQView';
 import { Library, LibrarySection, PlaylistCollection } from './components/Library';
 import { useLibrary } from './hooks/useLibrary';
 import { useLyrics } from './hooks/useLyrics';
@@ -12,7 +13,7 @@ import { Playlist } from './components/Playlist';
 import { SettingsView } from './components/SettingsView';
 import { AppLogo } from './components/AppLogo';
 import { WindowChrome } from './components/WindowChrome';
-import { getSettingsCopy, AppLanguage } from './lib/copy';
+import { getEQCopy, getSettingsCopy, AppLanguage } from './lib/copy';
 import { cn } from './lib/utils';
 import {
   AppSection,
@@ -33,13 +34,32 @@ const APP_NAME = 'RadiFlow Player';
 const APP_VERSION = '0.1.2';
 const PLAYLIST_STORAGE_KEY = 'apple-music-style-player.playlists';
 const PREFERENCES_STORAGE_KEY = 'apple-music-style-player.preferences';
-const PREFERENCES_STORAGE_VERSION = 3;
+const PREFERENCES_STORAGE_VERSION = 4;
 const PLAYBACK_SESSION_STORAGE_KEY = 'apple-music-style-player.playback-session';
 const PLAYBACK_SESSION_STORAGE_VERSION = 1;
 const DEFAULT_CUSTOM_BACKGROUND_BLUR = 72;
 const DEFAULT_TRANSPARENT_BACKGROUND_BLUR = 72;
 const MAX_CUSTOM_BACKGROUND_DIMENSION = 1920;
 const CUSTOM_BACKGROUND_OUTPUT_QUALITY = 0.84;
+const EQ_BANDS = [
+  { frequency: 31, label: '31 Hz' },
+  { frequency: 62, label: '62 Hz' },
+  { frequency: 125, label: '125 Hz' },
+  { frequency: 250, label: '250 Hz' },
+  { frequency: 500, label: '500 Hz' },
+  { frequency: 1000, label: '1 kHz' },
+  { frequency: 2000, label: '2 kHz' },
+  { frequency: 4000, label: '4 kHz' },
+  { frequency: 8000, label: '8 kHz' },
+  { frequency: 16000, label: '16 kHz' },
+] as const;
+const DEFAULT_EQ_GAINS = EQ_BANDS.map(() => 0);
+const clampEQGain = (value: number) => Math.max(-12, Math.min(12, value));
+const sanitizeEQGains = (value: unknown) => EQ_BANDS.map((_, index) => {
+  const candidate = Array.isArray(value) ? value[index] : 0;
+  return typeof candidate === 'number' && Number.isFinite(candidate) ? clampEQGain(candidate) : 0;
+});
+const isOverlaySection = (section: AppSection): section is 'settings' | 'eq' => section === 'settings' || section === 'eq';
 
 const compressBackgroundImageFile = (file: File) => new Promise<string>((resolve, reject) => {
   if (!file.type.startsWith('image/')) {
@@ -118,10 +138,13 @@ export default function App() {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [analyser, setAnalyser] = useState<AnalyserNode | null>(null);
   const [volume, setVolume] = useState(0.8);
+  const [eqEnabled, setEQEnabled] = useState(false);
+  const [eqGains, setEQGains] = useState<number[]>(DEFAULT_EQ_GAINS);
 
   const audioRef = useRef<HTMLAudioElement>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const sourceRef = useRef<MediaElementAudioSourceNode | null>(null);
+  const eqFiltersRef = useRef<BiquadFilterNode[]>([]);
   const hasActiveSong = currentIndex >= 0 && playbackQueue.length > 0 && song.title !== EMPTY_SONG.title;
 
   const {
@@ -137,6 +160,7 @@ export default function App() {
     enabled: hasActiveSong,
     title: song.title,
     artist: song.artist,
+    fileUrl: typeof song.file === 'string' ? song.file : undefined,
   });
 
   const handleManualLibraryRefresh = () => {
@@ -156,6 +180,8 @@ export default function App() {
       customBackgroundBlur,
       transparentBackgroundBlur,
       volume,
+      eqEnabled,
+      eqGains,
       loopMode,
       isShuffle,
     };
@@ -196,6 +222,11 @@ export default function App() {
   } as React.CSSProperties) : undefined;
 
   const settingsCopy = useMemo(() => getSettingsCopy(language), [language]);
+  const eqCopy = useMemo(() => getEQCopy(language), [language]);
+  const eqBands = useMemo(() => EQ_BANDS.map((band, index) => ({
+    ...band,
+    gain: eqGains[index] ?? 0,
+  })), [eqGains]);
   const uiText = useMemo(() => {
     if (language === 'zh-CN') {
       return {
@@ -208,6 +239,7 @@ export default function App() {
         albums: '专辑',
         search: '搜索',
         settings: '设置',
+        eq: '均衡器',
         createPlaylist: '新建播放列表',
         playlistPrefix: '播放列表',
         songsCount: (count: number) => `${count} 首歌曲`,
@@ -240,6 +272,7 @@ export default function App() {
         addNoop: '这些歌曲已存在于目标播放列表',
         playlistDeletedFallback: '已删除的播放列表',
         openSettings: '打开设置',
+        openEQ: '打开均衡器',
         settingsTransparentUnsupported: '当前系统不支持系统级毛玻璃透明背景',
         transparentModeEnableTitle: '启用透明背景',
         transparentModeEnableDescription: '透明背景仍属于实验性功能。确认后应用会立即重新启动，并切换到透明窗口模式。',
@@ -260,6 +293,7 @@ export default function App() {
       albums: 'Albums',
       search: 'Search',
       settings: 'Settings',
+      eq: 'Equalizer',
       createPlaylist: 'New Playlist',
       playlistPrefix: 'Playlist',
       songsCount: (count: number) => `${count} track${count === 1 ? '' : 's'}`,
@@ -292,6 +326,7 @@ export default function App() {
       addNoop: 'Those tracks are already in the target playlist',
       playlistDeletedFallback: 'Deleted playlist',
       openSettings: 'Open Settings',
+      openEQ: 'Open Equalizer',
       settingsTransparentUnsupported: 'System glass transparency is not supported on this machine',
       transparentModeEnableTitle: 'Enable Transparent Background',
       transparentModeEnableDescription: 'Transparent background is still experimental. Confirming will restart the app immediately and switch to transparent window mode.',
@@ -354,6 +389,16 @@ export default function App() {
     setBackgroundSource(source);
   };
 
+  const handleEQGainChange = (bandIndex: number, gain: number) => {
+    setEQGains((current) => current.map((value, index) => (
+      index === bandIndex ? clampEQGain(gain) : value
+    )));
+  };
+
+  const handleEQReset = () => {
+    setEQGains([...DEFAULT_EQ_GAINS]);
+  };
+
   const savedPlaylists = useMemo(
     () => rebuildPlaylistCollections(playlistDefinitions, librarySongs),
     [playlistDefinitions, librarySongs]
@@ -413,12 +458,27 @@ export default function App() {
       const analyserNode = context.createAnalyser();
       analyserNode.fftSize = 256;
 
+      const eqFilters = EQ_BANDS.map(({ frequency }, index) => {
+        const filter = context.createBiquadFilter();
+        filter.type = 'peaking';
+        filter.frequency.value = frequency;
+        filter.Q.value = 1.1;
+        filter.gain.value = eqEnabled ? eqGains[index] ?? 0 : 0;
+        return filter;
+      });
+
       const source = context.createMediaElementSource(audioRef.current);
-      source.connect(analyserNode);
+      let previousNode: AudioNode = source;
+      eqFilters.forEach((filter) => {
+        previousNode.connect(filter);
+        previousNode = filter;
+      });
+      previousNode.connect(analyserNode);
       analyserNode.connect(context.destination);
 
       audioContextRef.current = context;
       sourceRef.current = source;
+      eqFiltersRef.current = eqFilters;
       setAnalyser(analyserNode);
     }
 
@@ -426,6 +486,19 @@ export default function App() {
       audioContextRef.current.resume();
     }
   };
+
+  useEffect(() => {
+    const context = audioContextRef.current;
+    const filters = eqFiltersRef.current;
+    if (!context || filters.length === 0) {
+      return;
+    }
+
+    filters.forEach((filter, index) => {
+      const nextGain = eqEnabled ? clampEQGain(eqGains[index] ?? 0) : 0;
+      filter.gain.setTargetAtTime(nextGain, context.currentTime, 0.015);
+    });
+  }, [eqEnabled, eqGains]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -592,7 +665,7 @@ export default function App() {
       if (!rawPreferences) return;
 
       const parsed = JSON.parse(rawPreferences) as Partial<StoredPreferences>;
-      if (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== PREFERENCES_STORAGE_VERSION) return;
+      if (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== 3 && parsed.version !== PREFERENCES_STORAGE_VERSION) return;
 
       if (parsed.language === 'zh-CN' || parsed.language === 'en-US') {
         setLanguage(parsed.language);
@@ -620,6 +693,14 @@ export default function App() {
 
       if (typeof parsed.volume === 'number' && Number.isFinite(parsed.volume)) {
         setVolume(Math.min(1, Math.max(0, parsed.volume)));
+      }
+
+      if (typeof parsed.eqEnabled === 'boolean') {
+        setEQEnabled(parsed.eqEnabled);
+      }
+
+      if (Array.isArray(parsed.eqGains)) {
+        setEQGains(sanitizeEQGains(parsed.eqGains));
       }
 
       if (parsed.loopMode === 'none' || parsed.loopMode === 'all' || parsed.loopMode === 'one') {
@@ -702,12 +783,14 @@ export default function App() {
       customBackgroundBlur,
       transparentBackgroundBlur,
       volume,
+      eqEnabled,
+      eqGains,
       loopMode,
       isShuffle,
     };
 
     window.localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(preferences));
-  }, [hasLoadedPreferences, language, effect, backgroundSource, customBackgroundImage, customBackgroundBlur, transparentBackgroundBlur, volume, loopMode, isShuffle]);
+  }, [hasLoadedPreferences, language, effect, backgroundSource, customBackgroundImage, customBackgroundBlur, transparentBackgroundBlur, volume, eqEnabled, eqGains, loopMode, isShuffle]);
 
   useEffect(() => {
     if (!ipc || !hasLoadedPreferences) return;
@@ -1240,13 +1323,17 @@ export default function App() {
     setLastLibrarySection('playlists');
   };
 
-  const toggleSettings = () => {
-    if (currentSection === 'settings') {
+  const toggleOverlaySection = (section: 'settings' | 'eq') => {
+    if (currentSection === section) {
       setCurrentSection(lastLibrarySection);
-    } else {
-      setLastLibrarySection(currentSection as LibrarySection);
-      setCurrentSection('settings');
+      return;
     }
+
+    if (!isOverlaySection(currentSection)) {
+      setLastLibrarySection(currentSection);
+    }
+
+    setCurrentSection(section);
   };
 
   const handleWindowMinimize = () => {
@@ -1275,7 +1362,8 @@ export default function App() {
   };
 
   const isShowingPlaylistOverview = currentSection === 'playlists' && !displayedPlaylist;
-  const activeLibrarySection = currentSection === 'settings' ? lastLibrarySection : currentSection;
+  const overlaySection = isOverlaySection(currentSection) ? currentSection : null;
+  const activeLibrarySection = overlaySection ? lastLibrarySection : currentSection;
 
   const sidebarItems: Array<{ id: LibrarySection; label: string; icon: React.ReactNode }> = [
     { id: 'playlists', label: uiText.playlists, icon: <ListMusic size={18} /> },
@@ -1287,6 +1375,8 @@ export default function App() {
 
   const currentWindowSubtitle = currentSection === 'settings'
     ? uiText.settings
+    : currentSection === 'eq'
+      ? uiText.eq
     : view === 'player'
       ? (hasActiveSong ? `${uiText.nowPlaying} · ${song.title}` : uiText.noPlaybackTitle)
       : sidebarItems.find((item) => item.id === activeLibrarySection)?.label || uiText.brandSubtitle;
@@ -1301,20 +1391,37 @@ export default function App() {
         appName={APP_NAME}
         subtitle={currentWindowSubtitle}
         actionSlot={(
-          <button
-            type="button"
-            onClick={toggleSettings}
-            className={cn(
-              'h-9 rounded-xl border px-4 text-sm font-semibold flex items-center gap-2 transition-all',
-              currentSection === 'settings'
-                ? 'bg-white text-black border-white shadow-lg'
-                : 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10 hover:text-white'
-            )}
-            title={uiText.openSettings}
-          >
-            <Settings2 size={16} />
-            <span className="hidden sm:inline">{uiText.settings}</span>
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => toggleOverlaySection('eq')}
+              className={cn(
+                'h-9 rounded-xl border px-4 text-sm font-semibold flex items-center gap-2 transition-all',
+                currentSection === 'eq'
+                  ? 'bg-white text-black border-white shadow-lg'
+                  : 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10 hover:text-white'
+              )}
+              title={uiText.openEQ}
+            >
+              <SlidersHorizontal size={16} />
+              <span className="hidden sm:inline">{uiText.eq}</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => toggleOverlaySection('settings')}
+              className={cn(
+                'h-9 rounded-xl border px-4 text-sm font-semibold flex items-center gap-2 transition-all',
+                currentSection === 'settings'
+                  ? 'bg-white text-black border-white shadow-lg'
+                  : 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10 hover:text-white'
+              )}
+              title={uiText.openSettings}
+            >
+              <Settings2 size={16} />
+              <span className="hidden sm:inline">{uiText.settings}</span>
+            </button>
+          </div>
         )}
         showWindowControls={!!ipc}
         isWindowMaximized={isWindowMaximized}
@@ -1357,7 +1464,7 @@ export default function App() {
 
                 <div className="p-4 border-b border-white/10 space-y-2">
                   {sidebarItems.map((item) => {
-                    const isActive = activeLibrarySection === item.id && currentSection !== 'settings';
+                    const isActive = activeLibrarySection === item.id && !overlaySection;
                     return (
                       <button
                         key={item.id}
@@ -1657,41 +1764,53 @@ export default function App() {
         )}
       </AnimatePresence>
 
-      <AnimatePresence>
-        {currentSection === 'settings' && (
+      <AnimatePresence mode="wait">
+        {overlaySection && (
           <motion.div
+            key={overlaySection}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}
             className="absolute inset-x-0 top-14 bottom-0 z-105 p-4 md:p-6"
           >
             <div className="h-full rounded-4xl border border-white/10 bg-black/45 backdrop-blur-3xl customizable-backdrop-strong shadow-2xl overflow-hidden">
-              <SettingsView
-                copy={settingsCopy}
-                language={language}
-                onLanguageChange={setLanguage}
-                currentFolder={musicFolder}
-                isElectron={!!ipc}
-                onSelectFolder={selectFolder}
-                onOpenFolder={openFolder}
-                onRefreshLibrary={handleManualLibraryRefresh}
-                isRefreshingLibrary={isLoadingLibrary}
-                effect={effect}
-                backgroundSource={backgroundSource}
-                hasCustomBackground={Boolean(customBackgroundImage)}
-                customBackgroundBlur={customBackgroundBlur}
-                transparentBackgroundBlur={transparentBackgroundBlur}
-                supportsTransparentBackground={supportsTransparentBackground !== false}
-                onEffectChange={setEffect}
-                onBackgroundSourceChange={handleBackgroundSourceChange}
-                onSelectCustomBackground={handleSelectCustomBackground}
-                onRemoveCustomBackground={handleRemoveCustomBackground}
-                onCustomBackgroundBlurChange={setCustomBackgroundBlur}
-                onTransparentBackgroundBlurChange={setTransparentBackgroundBlur}
-                libraryCount={librarySongs.length}
-                appName={APP_NAME}
-                appVersion={APP_VERSION}
-              />
+              {overlaySection === 'settings' ? (
+                <SettingsView
+                  copy={settingsCopy}
+                  language={language}
+                  onLanguageChange={setLanguage}
+                  currentFolder={musicFolder}
+                  isElectron={!!ipc}
+                  onSelectFolder={selectFolder}
+                  onOpenFolder={openFolder}
+                  onRefreshLibrary={handleManualLibraryRefresh}
+                  isRefreshingLibrary={isLoadingLibrary}
+                  effect={effect}
+                  backgroundSource={backgroundSource}
+                  hasCustomBackground={Boolean(customBackgroundImage)}
+                  customBackgroundBlur={customBackgroundBlur}
+                  transparentBackgroundBlur={transparentBackgroundBlur}
+                  supportsTransparentBackground={supportsTransparentBackground !== false}
+                  onEffectChange={setEffect}
+                  onBackgroundSourceChange={handleBackgroundSourceChange}
+                  onSelectCustomBackground={handleSelectCustomBackground}
+                  onRemoveCustomBackground={handleRemoveCustomBackground}
+                  onCustomBackgroundBlurChange={setCustomBackgroundBlur}
+                  onTransparentBackgroundBlurChange={setTransparentBackgroundBlur}
+                  libraryCount={librarySongs.length}
+                  appName={APP_NAME}
+                  appVersion={APP_VERSION}
+                />
+              ) : (
+                <EQView
+                  copy={eqCopy}
+                  enabled={eqEnabled}
+                  bands={eqBands}
+                  onToggleEnabled={setEQEnabled}
+                  onBandGainChange={handleEQGainChange}
+                  onReset={handleEQReset}
+                />
+              )}
             </div>
           </motion.div>
         )}

--- a/src/components/EQView.tsx
+++ b/src/components/EQView.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { motion } from 'motion/react';
+import { Info, RotateCcw, SlidersHorizontal, Sparkles } from 'lucide-react';
+import { cn } from '../lib/utils';
+import { EQCopy } from '../lib/copy';
+
+interface EQBand {
+  frequency: number;
+  label: string;
+  gain: number;
+}
+
+interface EQViewProps {
+  copy: EQCopy;
+  enabled: boolean;
+  bands: EQBand[];
+  onToggleEnabled: (enabled: boolean) => void;
+  onBandGainChange: (index: number, gain: number) => void;
+  onReset: () => void;
+}
+
+interface CurvePoint {
+  x: number;
+  y: number;
+}
+
+const EQCard: React.FC<{
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ title, icon, children }) => (
+  <section className="rounded-3xl border border-white/10 bg-black/20 backdrop-blur-2xl customizable-backdrop-medium p-6 md:p-8 shadow-2xl">
+    <div className="mb-6 flex items-center gap-3 text-white">
+      <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-white/70">
+        {icon}
+      </div>
+      <h2 className="text-xl font-bold tracking-tight">{title}</h2>
+    </div>
+    {children}
+  </section>
+);
+
+const gainToRatio = (gain: number) => (Math.max(-12, Math.min(12, gain)) + 12) / 24;
+
+const buildCurvePath = (points: Array<{ x: number; y: number }>) => {
+  if (points.length === 0) {
+    return '';
+  }
+
+  if (points.length === 1) {
+    return `M ${points[0].x} ${points[0].y}`;
+  }
+
+  let path = `M ${points[0].x} ${points[0].y}`;
+
+  for (let index = 1; index < points.length; index += 1) {
+    const previousPoint = points[index - 1];
+    const currentPoint = points[index];
+    const midPointX = (previousPoint.x + currentPoint.x) / 2;
+    const midPointY = (previousPoint.y + currentPoint.y) / 2;
+    path += ` Q ${previousPoint.x} ${previousPoint.y} ${midPointX} ${midPointY}`;
+  }
+
+  const lastPoint = points[points.length - 1];
+  path += ` T ${lastPoint.x} ${lastPoint.y}`;
+  return path;
+};
+
+export const EQView: React.FC<EQViewProps> = ({
+  copy,
+  enabled,
+  bands,
+  onToggleEnabled,
+  onBandGainChange,
+  onReset,
+}) => {
+  const graphAreaRef = useRef<HTMLDivElement | null>(null);
+  const trackRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const [curveLayout, setCurveLayout] = useState<{ width: number; height: number; points: CurvePoint[] }>({
+    width: 100,
+    height: 100,
+    points: [],
+  });
+
+  useEffect(() => {
+    const updateCurveLayout = () => {
+      const graphArea = graphAreaRef.current;
+      if (!graphArea) {
+        return;
+      }
+
+      const graphRect = graphArea.getBoundingClientRect();
+      if (graphRect.width === 0 || graphRect.height === 0) {
+        return;
+      }
+
+      const points = bands
+        .map((band, index) => {
+          const track = trackRefs.current[index];
+          if (!track) {
+            return null;
+          }
+
+          const trackRect = track.getBoundingClientRect();
+          return {
+            x: trackRect.left + trackRect.width / 2 - graphRect.left,
+            y: trackRect.bottom - trackRect.height * gainToRatio(band.gain) - graphRect.top,
+          };
+        })
+        .filter((point): point is CurvePoint => point !== null);
+
+      setCurveLayout({
+        width: graphRect.width,
+        height: graphRect.height,
+        points,
+      });
+    };
+
+    updateCurveLayout();
+
+    const observer = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(() => updateCurveLayout())
+      : null;
+
+    if (observer) {
+      if (graphAreaRef.current) {
+        observer.observe(graphAreaRef.current);
+      }
+
+      trackRefs.current.forEach((track) => {
+        if (track) {
+          observer.observe(track);
+        }
+      });
+    }
+
+    window.addEventListener('resize', updateCurveLayout);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', updateCurveLayout);
+    };
+  }, [bands]);
+
+  const curvePath = useMemo(() => buildCurvePath(curveLayout.points), [curveLayout.points]);
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-6xl flex-col overflow-y-auto p-8 scrollbar-hide md:p-12">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="mb-10"
+      >
+        <h1 className="text-5xl font-black uppercase tracking-tighter text-white">{copy.title}</h1>
+        <p className="mt-2 text-xs font-mono uppercase tracking-widest text-white/40">{copy.subtitle}</p>
+      </motion.div>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <div className="space-y-6">
+          <EQCard title={copy.playback} icon={<SlidersHorizontal size={18} />}>
+            <div className="space-y-5">
+              <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-white">{copy.enableEQ}</p>
+                  <p className="mt-1 text-sm text-white/45">{copy.enableEQDescription}</p>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => onToggleEnabled(!enabled)}
+                  className={cn(
+                    'rounded-2xl border px-4 py-3 text-sm font-semibold transition-all',
+                    enabled
+                      ? 'border-white bg-white text-black shadow-lg'
+                      : 'border-white/10 bg-white/5 text-white/70 hover:bg-white/10 hover:text-white'
+                  )}
+                >
+                  {enabled ? copy.enabledState : copy.disabledState}
+                </button>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={onReset}
+                  className="flex items-center gap-2 rounded-2xl bg-white px-4 py-3 text-sm font-semibold text-black transition-transform hover:scale-[1.02]"
+                >
+                  <RotateCcw size={16} />
+                  {copy.reset}
+                </button>
+                <p className="text-sm text-white/45">{copy.resetDescription}</p>
+              </div>
+            </div>
+          </EQCard>
+
+          <EQCard title={copy.bands} icon={<Sparkles size={18} />}>
+            <div className="space-y-5">
+              <p className="text-sm text-white/45">{copy.bandsDescription}</p>
+              <div className="overflow-x-auto pb-2 scrollbar-hide">
+                <div className="relative min-w-[58rem] rounded-[2rem] border border-white/10 bg-white/[0.04] px-6 py-8">
+                  <div className="relative z-10 h-[22rem]">
+                    <div ref={graphAreaRef} className="pointer-events-none absolute inset-x-0 top-[2.1rem] bottom-[2.85rem] overflow-hidden">
+                      <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-white/10" />
+                      <div className="absolute inset-x-0 top-1/4 h-px bg-white/6" />
+                      <div className="absolute inset-x-0 bottom-1/4 h-px bg-white/6" />
+
+                      <svg
+                        viewBox={`0 0 ${Math.max(curveLayout.width, 1)} ${Math.max(curveLayout.height, 1)}`}
+                        preserveAspectRatio="none"
+                        className="absolute inset-0 h-full w-full"
+                      >
+                        <path
+                          d={curvePath}
+                          fill="none"
+                          stroke={enabled ? 'rgba(255,255,255,0.72)' : 'rgba(255,255,255,0.28)'}
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+
+                    <div className="relative grid h-full grid-cols-10 gap-3">
+                    {bands.map((band, index) => {
+                      const gainRatio = gainToRatio(band.gain);
+
+                      return (
+                        <div key={band.frequency} className="flex min-h-0 flex-col items-center">
+                          <span className="mb-3 text-[11px] font-mono uppercase tracking-[0.18em] text-white/55">
+                            {band.gain > 0 ? '+' : ''}{band.gain.toFixed(1)} {copy.gainUnit}
+                          </span>
+
+                          <div className="relative flex min-h-0 flex-1 items-center justify-center px-1">
+                            <div
+                              ref={(element) => {
+                                trackRefs.current[index] = element;
+                              }}
+                              className="absolute inset-y-3 left-1/2 w-1.5 -translate-x-1/2 overflow-hidden rounded-full bg-white/10"
+                            >
+                              <div
+                                className={cn(
+                                  'absolute inset-x-0 bottom-0 rounded-full transition-all',
+                                  enabled ? 'bg-white/85' : 'bg-white/35'
+                                )}
+                                style={{ height: `${gainRatio * 100}%` }}
+                              />
+                            </div>
+
+                            <input
+                              type="range"
+                              min="-12"
+                              max="12"
+                              step="0.5"
+                              value={band.gain}
+                              onChange={(event) => onBandGainChange(index, Number.parseFloat(event.target.value))}
+                              className="relative z-10 w-[14rem] -rotate-90 cursor-pointer appearance-none bg-transparent accent-white"
+                            />
+                          </div>
+
+                          <div className="mt-3 flex flex-col items-center gap-1">
+                            <span className="text-xs font-semibold text-white">{band.label}</span>
+                            <span className="text-[10px] uppercase tracking-[0.18em] text-white/30">{copy.gainLabel}</span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                    </div>
+                  </div>
+
+                  <div className="relative z-10 mt-4 flex items-center justify-between text-xs text-white/35">
+                    <span>-12 {copy.gainUnit}</span>
+                    <span>0 {copy.gainUnit}</span>
+                    <span>+12 {copy.gainUnit}</span>
+                  </div>
+                </div>
+
+                <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-white/35">
+                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1">{copy.rangeLabel}: -12 {copy.gainUnit} / +12 {copy.gainUnit}</span>
+                  <span>{copy.previewHint}</span>
+                </div>
+              </div>
+            </div>
+          </EQCard>
+        </div>
+
+        <div className="space-y-6">
+          <EQCard title={copy.summary} icon={<Info size={18} />}>
+            <div className="space-y-4 text-sm text-white/75">
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4">
+                <p className="text-white/55">{copy.statusLabel}</p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {enabled ? copy.enabledState : copy.disabledState}
+                </p>
+              </div>
+
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4">
+                <p className="text-white/55">{copy.rangeLabel}</p>
+                <p className="mt-2 font-semibold text-white">-12 dB to +12 dB</p>
+              </div>
+
+              <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-4 leading-6 text-white/70">
+                <p>{copy.summaryDescription}</p>
+                <p className="mt-3 text-white/45">{copy.previewHint}</p>
+              </div>
+            </div>
+          </EQCard>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -12,9 +12,10 @@ interface UseLyricsOptions {
   enabled: boolean;
   title: string;
   artist: string;
+  fileUrl?: string;
 }
 
-export function useLyrics({ enabled, title, artist }: UseLyricsOptions) {
+export function useLyrics({ enabled, title, artist, fileUrl }: UseLyricsOptions) {
   const [lyrics, setLyrics] = useState<LyricLine[]>([]);
   const [isLoadingLyrics, setIsLoadingLyrics] = useState(false);
   const cacheRef = useRef(new Map<string, CachedLyricsPayload>());
@@ -28,12 +29,16 @@ export function useLyrics({ enabled, title, artist }: UseLyricsOptions) {
 
     const normalizedTitle = title.trim();
     const normalizedArtist = artist.trim();
+    const normalizedFileUrl = fileUrl?.trim() ?? '';
     if (!normalizedTitle || !normalizedArtist) {
+      setIsLoadingLyrics(false);
       setLyrics(parseLRC(EMPTY_LRC_TEXT));
       return;
     }
 
-    const cacheKey = `${normalizedTitle}::${normalizedArtist}`.toLowerCase();
+    const cacheKey = normalizedFileUrl
+      ? `file:${normalizedFileUrl}`
+      : `track:${normalizedTitle}::${normalizedArtist}`.toLowerCase();
     const cached = cacheRef.current.get(cacheKey);
     if (cached) {
       setLyrics(cached.lyrics);
@@ -47,23 +52,15 @@ export function useLyrics({ enabled, title, artist }: UseLyricsOptions) {
     const fetchLyrics = async () => {
       setIsLoadingLyrics(true);
       try {
-        const searchResponse = await fetch(`/api/proxy/search?word=${encodeURIComponent(`${normalizedTitle} ${normalizedArtist}`)}`, {
-          signal: controller.signal,
+        const searchParams = new URLSearchParams({
+          title: normalizedTitle,
+          artist: normalizedArtist,
         });
-        const searchData = await searchResponse.json();
-        const results = Array.isArray(searchData.data) ? searchData.data : searchData.data?.list;
-
-        if (searchData.code !== 200 || !results?.length) {
-          throw new Error('Song not found in search results');
+        if (normalizedFileUrl) {
+          searchParams.set('file', normalizedFileUrl);
         }
 
-        const firstSong = results[0];
-        const songId = firstSong.id || firstSong.songid || firstSong.songmid;
-        if (!songId) {
-          throw new Error('Could not find song ID');
-        }
-
-        const lyricResponse = await fetch(`/api/proxy/lyric?id=${songId}`, {
+        const lyricResponse = await fetch(`/api/lyrics?${searchParams.toString()}`, {
           signal: controller.signal,
         });
         const lyricData = await lyricResponse.json();
@@ -99,10 +96,6 @@ export function useLyrics({ enabled, title, artist }: UseLyricsOptions) {
 
         console.error('Failed to fetch lyrics:', error);
         const fallbackLyrics = parseLRC(EMPTY_LRC_TEXT);
-        cacheRef.current.set(cacheKey, {
-          rawText: EMPTY_LRC_TEXT,
-          lyrics: fallbackLyrics,
-        });
         setLyrics(fallbackLyrics);
       } finally {
         if (!isCancelled) {
@@ -117,7 +110,7 @@ export function useLyrics({ enabled, title, artist }: UseLyricsOptions) {
       isCancelled = true;
       controller.abort();
     };
-  }, [artist, enabled, title]);
+  }, [artist, enabled, fileUrl, title]);
 
   return { lyrics, isLoadingLyrics };
 }

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -116,12 +116,34 @@ export interface SettingsCopy {
 	tracksCount: (count: number) => string;
 }
 
+export interface EQCopy {
+	title: string;
+	subtitle: string;
+	playback: string;
+	enableEQ: string;
+	enableEQDescription: string;
+	enabledState: string;
+	disabledState: string;
+	reset: string;
+	resetDescription: string;
+	bands: string;
+	bandsDescription: string;
+	summary: string;
+	summaryDescription: string;
+	gainLabel: string;
+	gainUnit: string;
+	rangeLabel: string;
+	statusLabel: string;
+	previewHint: string;
+}
+
 export interface AppCopy {
 	common: CommonCopy;
 	sidebar: SidebarCopy;
 	playlist: PlaylistCopy;
 	library: LibraryCopy;
 	settings: SettingsCopy;
+	eq: EQCopy;
 }
 
 export const APP_COPY: Record<AppLanguage, AppCopy> = {
@@ -237,6 +259,26 @@ export const APP_COPY: Record<AppLanguage, AppCopy> = {
 			libraryStats: '曲库数量',
 			tracksCount: (count) => `${count} 首歌曲`,
 		},
+		eq: {
+			title: '均衡器',
+			subtitle: '播放链路与频段增益控制',
+			playback: '播放处理',
+			enableEQ: '启用 EQ',
+			enableEQDescription: '在当前播放器的 Web Audio 链中启用多段均衡器处理。',
+			enabledState: '已启用',
+			disabledState: '已关闭',
+			reset: '重置频段',
+			resetDescription: '将所有频段恢复到 0 dB，不会影响当前音量。',
+			bands: '频段控制',
+			bandsDescription: '调节不同频率范围的增益，范围为 -12 dB 到 +12 dB。',
+			summary: '状态摘要',
+			summaryDescription: 'EQ 会直接作用于当前播放输出；切歌和暂停恢复后会保持设置。',
+			gainLabel: '增益',
+			gainUnit: 'dB',
+			rangeLabel: '范围',
+			statusLabel: '当前状态',
+			previewHint: '频谱可视化会反映 EQ 处理后的频率变化。',
+		},
 	},
 	'en-US': {
 		common: {
@@ -350,7 +392,28 @@ export const APP_COPY: Record<AppLanguage, AppCopy> = {
 			libraryStats: 'Library Size',
 			tracksCount: (count) => `${count} tracks`,
 		},
+		eq: {
+			title: 'Equalizer',
+			subtitle: 'Playback processing and band gain control',
+			playback: 'Playback Processing',
+			enableEQ: 'Enable EQ',
+			enableEQDescription: 'Enable multi-band equalizer processing in the current Web Audio playback chain.',
+			enabledState: 'Enabled',
+			disabledState: 'Disabled',
+			reset: 'Reset Bands',
+			resetDescription: 'Restore every band to 0 dB without changing the master volume.',
+			bands: 'Band Controls',
+			bandsDescription: 'Adjust gain across different frequency ranges, from -12 dB to +12 dB.',
+			summary: 'Status Summary',
+			summaryDescription: 'EQ is applied directly to the active playback output and stays active across track changes and pause/resume.',
+			gainLabel: 'Gain',
+			gainUnit: 'dB',
+			rangeLabel: 'Range',
+			statusLabel: 'Current Status',
+			previewHint: 'The spectrum visualizer reflects the post-EQ frequency response.',
+		},
 	},
 };
 
 export const getSettingsCopy = (language: AppLanguage): SettingsCopy => APP_COPY[language].settings;
+export const getEQCopy = (language: AppLanguage): EQCopy => APP_COPY[language].eq;

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -29,7 +29,7 @@ export const EMPTY_SONG: Song = {
   lrc: '',
 };
 
-export type AppSection = LibrarySection | 'settings';
+export type AppSection = LibrarySection | 'settings' | 'eq';
 
 export interface StoredPlaylist {
   id: string;
@@ -47,6 +47,8 @@ export interface StoredPreferences {
   customBackgroundBlur?: number;
   transparentBackgroundBlur?: number;
   volume: number;
+  eqEnabled?: boolean;
+  eqGains?: number[];
   loopMode: LoopMode;
   isShuffle: boolean;
 }


### PR DESCRIPTION
Introduce a multi-band equalizer UI and integrate persistent lyric caching/storage. Adds a new EQView component and EQ state (bands, enabled flag, persistence) to the app, wired into the WebAudio graph via BiquadFilterNodes and persisted in preferences (storage version bumped). Update copy strings and exports (getEQCopy) and add UI controls to toggle/open the EQ overlay. On the server side, implement a lyrics subsystem: add /api/lyrics endpoint, support manual lyric files (.lrc/.yrc/.txt), introduce a sqlite-backed lyric_cache with migration from legacy JSON index files, and helper utilities for sanitizing, persisting and retrieving lyric payloads. Also update the useLyrics hook to accept fileUrl and query the new /api/lyrics endpoint.