### PR TITLE
Add marquee scrolling for overflowing titles

### DIFF
--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -93,7 +93,9 @@ export const MiniPlayer: React.FC<MiniPlayerProps> = ({
 
         {/* Info */}
         <div className="flex-1 min-w-0">
-          <h4 className="text-sm font-bold text-white truncate">{title}</h4>
+          <div className="marquee-container">
+            <h4 className="marquee-text text-sm font-bold text-white">{title}</h4>
+          </div>
           <p className="text-xs text-white/40 truncate">{artist}</p>
         </div>
 

--- a/src/components/PlayerControls.tsx
+++ b/src/components/PlayerControls.tsx
@@ -116,8 +116,10 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
   return (
     <div className="flex flex-col gap-6 w-full max-w-md">
       <div className="flex items-start justify-between overflow-hidden pl-4">
-        <div className="flex flex-col min-w-0">
-          <h3 className="text-white font-bold text-3xl truncate">{title}</h3>
+        <div className="flex flex-col min-w-0 gap-1">
+          <div className="marquee-container">
+            <h3 className="marquee-text text-white font-bold text-3xl">{title}</h3>
+          </div>
           <p className="text-white/60 text-lg truncate">{artist}</p>
         </div>
         <button 

--- a/src/index.css
+++ b/src/index.css
@@ -47,3 +47,31 @@ body {
 [data-custom-background='true'] .customizable-backdrop-strong {
   backdrop-filter: blur(var(--rf-custom-blur-strong)) !important;
 }
+
+/* Marquee scrolling text — used for song title that may overflow */
+@keyframes marquee-scroll {
+  0%      { transform: translateX(0); opacity: 1; filter: blur(0px); }
+  /* Hold at start */
+  15%     { transform: translateX(0); opacity: 1; filter: blur(0px); }
+  /* Scroll to end */
+  72%     { transform: translateX(var(--marquee-distance, -60%)); opacity: 1; filter: blur(0px); }
+  /* Blur + fade out at end (~0.7s) */
+  77%     { transform: translateX(var(--marquee-distance, -60%)); opacity: 0; filter: blur(8px); }
+  /* Snap back to start while invisible */
+  78%     { transform: translateX(0); opacity: 0; filter: blur(8px); }
+  /* Blur + fade in at start (~0.7s) */
+  83%     { transform: translateX(0); opacity: 1; filter: blur(0px); }
+  /* Hold at start before next cycle */
+  100%    { transform: translateX(0); opacity: 1; filter: blur(0px); }
+}
+
+@utility marquee-container {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+@utility marquee-text {
+  display: inline-block;
+  animation: marquee-scroll 14s linear infinite;
+  will-change: transform;
+}


### PR DESCRIPTION
Wrap song title elements in a marquee container and introduce marquee-text styling so long titles scroll instead of being truncated. Updated MiniPlayer and PlayerControls to use the marquee markup and kept artist text as truncated. Added CSS keyframes (marquee-scroll), utility classes (marquee-container, marquee-text), and a --marquee-distance hook with a 14s animation including subtle blur/fade to smooth the loop.